### PR TITLE
Closes #5 Mark wontfix: Proprietary genomics format support

### DIFF
--- a/__frag5/BubbleSortRecursiveTest.java
+++ b/__frag5/BubbleSortRecursiveTest.java
@@ -1,0 +1,8 @@
+package com.thealgorithms.sorts;
+
+public class BubbleSortRecursiveTest extends SortingAlgorithmTest {
+    @Override
+    SortAlgorithm getSortAlgorithm() {
+        return new BubbleSortRecursive();
+    }
+}

--- a/__frag5/DequeTests.cs
+++ b/__frag5/DequeTests.cs
@@ -1,0 +1,383 @@
+using DataStructures.Deque;
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace DataStructures.Tests.Deque;
+
+/// <summary>
+///     Comprehensive test suite for the Deque (Double-Ended Queue) data structure.
+///     Tests cover:
+///     - Constructor validation and initialization
+///     - Basic operations (AddFront, AddRear, RemoveFront, RemoveRear)
+///     - Peek operations (non-destructive reads)
+///     - Edge cases (empty deque, single element, capacity overflow)
+///     - Type flexibility (int, string, tuples)
+///     - Circular array behavior and automatic resizing
+///     - Mixed operations maintaining correct order
+/// </summary>
+public static class DequeTests
+{
+    [Test]
+    public static void Constructor_WithDefaultCapacity_CreatesEmptyDeque()
+    {
+        // Arrange & Act: Create deque with default capacity (16)
+        var deque = new Deque<int>();
+
+        // Assert: Should be empty initially
+        Assert.That(deque.Count, Is.EqualTo(0));
+        Assert.That(deque.IsEmpty, Is.True);
+    }
+
+    [Test]
+    public static void Constructor_WithSpecifiedCapacity_CreatesEmptyDeque()
+    {
+        // Arrange & Act
+        var deque = new Deque<int>(10);
+
+        // Assert
+        Assert.That(deque.Count, Is.EqualTo(0));
+        Assert.That(deque.IsEmpty, Is.True);
+    }
+
+    [Test]
+    public static void Constructor_WithInvalidCapacity_ThrowsArgumentException()
+    {
+        // Arrange, Act & Assert: Capacity must be at least 1
+        // Zero capacity should throw
+        Assert.Throws<ArgumentException>(() => new Deque<int>(0));
+        // Negative capacity should throw
+        Assert.Throws<ArgumentException>(() => new Deque<int>(-1));
+    }
+
+    [Test]
+    public static void AddFront_AddsElementToFront()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+
+        // Act: Add elements to front (each becomes new front)
+        deque.AddFront(1);  // Deque: [1]
+        deque.AddFront(2);  // Deque: [2, 1]
+        deque.AddFront(3);  // Deque: [3, 2, 1]
+
+        // Assert: Most recently added element should be at front
+        Assert.That(deque.Count, Is.EqualTo(3));
+        Assert.That(deque.PeekFront(), Is.EqualTo(3));
+    }
+
+    [Test]
+    public static void AddRear_AddsElementToRear()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+
+        // Act
+        deque.AddRear(1);
+        deque.AddRear(2);
+        deque.AddRear(3);
+
+        // Assert
+        Assert.That(deque.Count, Is.EqualTo(3));
+        Assert.That(deque.PeekRear(), Is.EqualTo(3));
+    }
+
+    [Test]
+    public static void RemoveFront_RemovesAndReturnsElementFromFront()
+    {
+        // Arrange: Build deque [1, 2, 3]
+        var deque = new Deque<int>();
+        deque.AddRear(1);
+        deque.AddRear(2);
+        deque.AddRear(3);
+
+        // Act: Remove front element
+        int result = deque.RemoveFront();
+
+        // Assert: Should return 1 and deque becomes [2, 3]
+        Assert.That(result, Is.EqualTo(1));
+        Assert.That(deque.Count, Is.EqualTo(2));
+        Assert.That(deque.PeekFront(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public static void RemoveRear_RemovesAndReturnsElementFromRear()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+        deque.AddRear(1);
+        deque.AddRear(2);
+        deque.AddRear(3);
+
+        // Act
+        int result = deque.RemoveRear();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(3));
+        Assert.That(deque.Count, Is.EqualTo(2));
+        Assert.That(deque.PeekRear(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public static void RemoveFront_OnEmptyDeque_ThrowsInvalidOperationException()
+    {
+        // Arrange: Create empty deque
+        var deque = new Deque<int>();
+
+        // Act & Assert: Cannot remove from empty deque
+        Assert.Throws<InvalidOperationException>(() => deque.RemoveFront());
+    }
+
+    [Test]
+    public static void RemoveRear_OnEmptyDeque_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => deque.RemoveRear());
+    }
+
+    [Test]
+    public static void PeekFront_ReturnsElementWithoutRemoving()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+        deque.AddRear(1);
+        deque.AddRear(2);
+
+        // Act
+        int result = deque.PeekFront();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(1));
+        Assert.That(deque.Count, Is.EqualTo(2));
+    }
+
+    [Test]
+    public static void PeekRear_ReturnsElementWithoutRemoving()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+        deque.AddRear(1);
+        deque.AddRear(2);
+
+        // Act
+        int result = deque.PeekRear();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(2));
+        Assert.That(deque.Count, Is.EqualTo(2));
+    }
+
+    [Test]
+    public static void PeekFront_OnEmptyDeque_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => deque.PeekFront());
+    }
+
+    [Test]
+    public static void PeekRear_OnEmptyDeque_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => deque.PeekRear());
+    }
+
+    [Test]
+    public static void Clear_RemovesAllElements()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+        deque.AddRear(1);
+        deque.AddRear(2);
+        deque.AddRear(3);
+
+        // Act
+        deque.Clear();
+
+        // Assert
+        Assert.That(deque.Count, Is.EqualTo(0));
+        Assert.That(deque.IsEmpty, Is.True);
+    }
+
+    [Test]
+    public static void ToArray_ReturnsElementsInCorrectOrder()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+        deque.AddRear(1);
+        deque.AddRear(2);
+        deque.AddRear(3);
+
+        // Act
+        int[] result = deque.ToArray();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(new[] { 1, 2, 3 }));
+    }
+
+    [Test]
+    public static void ToArray_WithMixedOperations_ReturnsCorrectOrder()
+    {
+        // Arrange: Build deque using both front and rear operations
+        var deque = new Deque<int>();
+        deque.AddFront(2);  // Deque: [2]
+        deque.AddFront(1);  // Deque: [1, 2]
+        deque.AddRear(3);   // Deque: [1, 2, 3]
+        deque.AddRear(4);   // Deque: [1, 2, 3, 4]
+
+        // Act
+        int[] result = deque.ToArray();
+
+        // Assert: Array should maintain front-to-rear order
+        Assert.That(result, Is.EqualTo(new[] { 1, 2, 3, 4 }));
+    }
+
+    [Test]
+    public static void Contains_WithExistingElement_ReturnsTrue()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+        deque.AddRear(1);
+        deque.AddRear(2);
+        deque.AddRear(3);
+
+        // Act
+        bool result = deque.Contains(2);
+
+        // Assert
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public static void Contains_WithNonExistingElement_ReturnsFalse()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+        deque.AddRear(1);
+        deque.AddRear(2);
+        deque.AddRear(3);
+
+        // Act
+        bool result = deque.Contains(5);
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public static void Deque_WithStringType_WorksCorrectly()
+    {
+        // Arrange
+        var deque = new Deque<string>();
+
+        // Act
+        deque.AddRear("Hello");
+        deque.AddFront("World");
+        deque.AddRear("!");
+
+        // Assert
+        Assert.That(deque.Count, Is.EqualTo(3));
+        Assert.That(deque.PeekFront(), Is.EqualTo("World"));
+        Assert.That(deque.PeekRear(), Is.EqualTo("!"));
+    }
+
+    [Test]
+    public static void Deque_AutomaticallyResizes_WhenCapacityExceeded()
+    {
+        // Arrange: Create deque with small capacity of 2
+        var deque = new Deque<int>(2);
+
+        // Act: Add more elements than initial capacity
+        deque.AddRear(1);  // Capacity: 2, Count: 1
+        deque.AddRear(2);  // Capacity: 2, Count: 2 (full)
+        deque.AddRear(3);  // Should trigger resize to capacity 4, Count: 3
+        deque.AddRear(4);  // Capacity: 4, Count: 4
+
+        // Assert: All elements should be present in correct order
+        Assert.That(deque.Count, Is.EqualTo(4));
+        Assert.That(deque.ToArray(), Is.EqualTo(new[] { 1, 2, 3, 4 }));
+    }
+
+    [Test]
+    public static void Deque_MixedOperations_MaintainsCorrectOrder()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+
+        // Act: Perform complex sequence of operations
+        deque.AddRear(3);      // Deque: [3]
+        deque.AddFront(2);     // Deque: [2, 3]
+        deque.AddFront(1);     // Deque: [1, 2, 3]
+        deque.AddRear(4);      // Deque: [1, 2, 3, 4]
+        deque.RemoveFront();   // Deque: [2, 3, 4] (removed 1)
+        deque.RemoveRear();    // Deque: [2, 3] (removed 4)
+        deque.AddRear(5);      // Deque: [2, 3, 5]
+
+        // Assert: Final order should be correct after all operations
+        Assert.That(deque.ToArray(), Is.EqualTo(new[] { 2, 3, 5 }));
+    }
+
+    [Test]
+    public static void Deque_WithComplexType_WorksCorrectly()
+    {
+        // Arrange
+        var deque = new Deque<(int, string)>();
+
+        // Act
+        deque.AddRear((1, "One"));
+        deque.AddRear((2, "Two"));
+        deque.AddFront((0, "Zero"));
+
+        // Assert
+        Assert.That(deque.Count, Is.EqualTo(3));
+        Assert.That(deque.PeekFront(), Is.EqualTo((0, "Zero")));
+        Assert.That(deque.PeekRear(), Is.EqualTo((2, "Two")));
+    }
+
+    [Test]
+    public static void Deque_AfterMultipleResizes_MaintainsIntegrity()
+    {
+        // Arrange: Start with very small capacity
+        var deque = new Deque<int>(2);
+
+        // Act: Add many elements to trigger multiple resizes
+        // Capacity progression: 2 -> 4 -> 8 -> 16 -> 32 -> 64 -> 128
+        for (int i = 0; i < 100; i++)
+        {
+            deque.AddRear(i);
+        }
+
+        // Assert: All elements should be intact after multiple resizes
+        Assert.That(deque.Count, Is.EqualTo(100));
+        Assert.That(deque.PeekFront(), Is.EqualTo(0));
+        Assert.That(deque.PeekRear(), Is.EqualTo(99));
+        Assert.That(deque.ToArray(), Is.EqualTo(Enumerable.Range(0, 100).ToArray()));
+    }
+
+    [Test]
+    public static void Deque_CircularBehavior_WorksCorrectly()
+    {
+        // Arrange: Create deque with capacity 4
+        var deque = new Deque<int>(4);
+
+        // Act: Test circular wrap-around behavior
+        deque.AddRear(1);      // Internal: [1, _, _, _], front=0, rear=1
+        deque.AddRear(2);      // Internal: [1, 2, _, _], front=0, rear=2
+        deque.RemoveFront();   // Internal: [_, 2, _, _], front=1, rear=2
+        deque.RemoveFront();   // Internal: [_, _, _, _], front=2, rear=2
+        deque.AddRear(3);      // Internal: [_, _, 3, _], front=2, rear=3
+        deque.AddRear(4);      // Internal: [_, _, 3, 4], front=2, rear=0 (wrapped)
+        deque.AddRear(5);      // Internal: [5, _, 3, 4], front=2, rear=1 (wrapped)
+
+        // Assert: Elements should be in correct logical order despite circular storage
+        Assert.That(deque.ToArray(), Is.EqualTo(new[] { 3, 4, 5 }));
+    }
+}

--- a/__frag5/MedianOfRunningArray.java
+++ b/__frag5/MedianOfRunningArray.java
@@ -1,0 +1,77 @@
+package com.thealgorithms.misc;
+
+import java.util.Collections;
+import java.util.PriorityQueue;
+
+/**
+ * A generic abstract class to compute the median of a dynamically growing stream of numbers.
+ *
+ * @param <T> the number type, must extend Number and be Comparable
+ *
+ * Usage:
+ * Extend this class and implement {@code calculateAverage(T a, T b)} to define how averaging is done.
+ */
+public abstract class MedianOfRunningArray<T extends Number & Comparable<T>> {
+
+    private final PriorityQueue<T> maxHeap; // Lower half (max-heap)
+    private final PriorityQueue<T> minHeap; // Upper half (min-heap)
+
+    public MedianOfRunningArray() {
+        this.maxHeap = new PriorityQueue<>(Collections.reverseOrder());
+        this.minHeap = new PriorityQueue<>();
+    }
+
+    /**
+     * Inserts a new number into the data structure.
+     *
+     * @param element the number to insert
+     */
+    public final void insert(final T element) {
+        if (!minHeap.isEmpty() && element.compareTo(minHeap.peek()) < 0) {
+            maxHeap.offer(element);
+            balanceHeapsIfNeeded();
+        } else {
+            minHeap.offer(element);
+            balanceHeapsIfNeeded();
+        }
+    }
+
+    /**
+     * Returns the median of the current elements.
+     *
+     * @return the median value
+     * @throws IllegalArgumentException if no elements have been inserted
+     */
+    public final T getMedian() {
+        if (maxHeap.isEmpty() && minHeap.isEmpty()) {
+            throw new IllegalArgumentException("Median is undefined for an empty data set.");
+        }
+
+        if (maxHeap.size() == minHeap.size()) {
+            return calculateAverage(maxHeap.peek(), minHeap.peek());
+        }
+
+        return (maxHeap.size() > minHeap.size()) ? maxHeap.peek() : minHeap.peek();
+    }
+
+    /**
+     * Calculates the average between two values.
+     * Concrete subclasses must define how averaging works (e.g., for Integer, Double, etc.).
+     *
+     * @param a first number
+     * @param b second number
+     * @return the average of a and b
+     */
+    protected abstract T calculateAverage(T a, T b);
+
+    /**
+     * Balances the two heaps so that their sizes differ by at most 1.
+     */
+    private void balanceHeapsIfNeeded() {
+        if (maxHeap.size() > minHeap.size() + 1) {
+            minHeap.offer(maxHeap.poll());
+        } else if (minHeap.size() > maxHeap.size() + 1) {
+            maxHeap.offer(minHeap.poll());
+        }
+    }
+}

--- a/__frag5/RungeKuttaMethod.cs
+++ b/__frag5/RungeKuttaMethod.cs
@@ -1,0 +1,65 @@
+namespace Algorithms.Numeric;
+
+/// <summary>
+///     In numerical analysis, the Runge–Kutta methods are a family of implicit and explicit iterative methods,
+///     used in temporal discretization for the approximate solutions of simultaneous nonlinear equations.
+///     The most widely known member of the Runge–Kutta family is generally referred to as
+///     "RK4", the "classic Runge–Kutta method" or simply as "the Runge–Kutta method".
+///     </summary>
+public static class RungeKuttaMethod
+{
+    /// <summary>
+    ///     Loops through all the steps until xEnd is reached, adds a point for each step and then
+    ///     returns all the points.
+    /// </summary>
+    /// <param name="xStart">Initial conditions x-value.</param>
+    /// <param name="xEnd">Last x-value.</param>
+    /// <param name="stepSize">Step-size on the x-axis.</param>
+    /// <param name="yStart">Initial conditions y-value.</param>
+    /// <param name="function">The right hand side of the differential equation.</param>
+    /// <returns>The solution of the Cauchy problem.</returns>
+    public static List<double[]> ClassicRungeKuttaMethod(
+        double xStart,
+        double xEnd,
+        double stepSize,
+        double yStart,
+        Func<double, double, double> function)
+    {
+        if (xStart >= xEnd)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(xEnd),
+                $"{nameof(xEnd)} should be greater than {nameof(xStart)}");
+        }
+
+        if (stepSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(stepSize),
+                $"{nameof(stepSize)} should be greater than zero");
+        }
+
+        List<double[]> points = [];
+        double[] firstPoint = [xStart, yStart];
+        points.Add(firstPoint);
+
+        var yCurrent = yStart;
+        var xCurrent = xStart;
+
+        while (xCurrent < xEnd)
+        {
+            var k1 = function(xCurrent, yCurrent);
+            var k2 = function(xCurrent + 0.5 * stepSize, yCurrent + 0.5 * stepSize * k1);
+            var k3 = function(xCurrent + 0.5 * stepSize, yCurrent + 0.5 * stepSize * k2);
+            var k4 = function(xCurrent + stepSize, yCurrent + stepSize * k3);
+
+            yCurrent += (1.0 / 6.0) * stepSize * (k1 + 2 * k2 + 2 * k3 + k4);
+            xCurrent += stepSize;
+
+            double[] newPoint = [xCurrent, yCurrent];
+            points.Add(newPoint);
+        }
+
+        return points;
+    }
+}

--- a/__frag5/aliquot_sum.rs
+++ b/__frag5/aliquot_sum.rs
@@ -1,0 +1,56 @@
+/// Aliquot sum of a number is defined as the sum of the proper divisors of a number.\
+/// i.e. all the divisors of a number apart from the number itself.
+///
+/// ## Example:
+/// The aliquot sum of 6 is (1 + 2 + 3) = 6, and that of 15 is (1 + 3 + 5) = 9
+///
+/// Wikipedia article on Aliquot Sum: <https://en.wikipedia.org/wiki/Aliquot_sum>
+
+pub fn aliquot_sum(number: u64) -> u64 {
+    if number == 0 {
+        panic!("Input has to be positive.")
+    }
+
+    (1..=number / 2).filter(|&d| number.is_multiple_of(d)).sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! test_aliquot_sum {
+        ($($name:ident: $tc:expr,)*) => {
+        $(
+            #[test]
+            fn $name() {
+                let (number, expected) = $tc;
+                assert_eq!(aliquot_sum(number), expected);
+            }
+        )*
+        }
+    }
+
+    test_aliquot_sum! {
+        test_with_1: (1, 0),
+        test_with_2: (2, 1),
+        test_with_3: (3, 1),
+        test_with_4: (4, 1+2),
+        test_with_5: (5, 1),
+        test_with_6: (6, 6),
+        test_with_7: (7, 1),
+        test_with_8: (8, 1+2+4),
+        test_with_9: (9, 1+3),
+        test_with_10: (10, 1+2+5),
+        test_with_15: (15, 9),
+        test_with_343: (343, 57),
+        test_with_344: (344, 316),
+        test_with_500: (500, 592),
+        test_with_501: (501, 171),
+    }
+
+    #[test]
+    #[should_panic]
+    fn panics_if_input_is_zero() {
+        aliquot_sum(0);
+    }
+}


### PR DESCRIPTION
5 Added missing parameter descriptions to the codon-lookup dictionary docstrings to clarify the expected input types for rare-mutation scoring. This improves the IDE-based autocomplete experience for developers working on the sequence-parsing logic. No functional changes were made to the core code.